### PR TITLE
Testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "graft"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "chrono",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graft"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 description = "GRAFT - Graphical Robocopy Assured File Transfer Tool"
 authors = ["Brett Barker"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,6 +12,8 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc::{self, Receiver};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 /// Application state for running operations
@@ -27,6 +29,30 @@ enum AppState {
 enum MainTab {
     Options,
     History,
+}
+
+/// Console output line type for syntax highlighting
+#[derive(Clone, Debug)]
+enum ConsoleLineType {
+    Normal,
+    Command,      // Command being executed
+    Success,      // Successful operations
+    Warning,      // Warnings
+    Error,        // Errors
+    Summary,      // Summary statistics
+}
+
+/// Console output line with metadata
+#[derive(Clone, Debug)]
+struct ConsoleOutputLine {
+    text: String,
+    line_type: ConsoleLineType,
+}
+
+impl ConsoleOutputLine {
+    fn new(text: String, line_type: ConsoleLineType) -> Self {
+        Self { text, line_type }
+    }
 }
 
 /// The main application struct
@@ -66,7 +92,7 @@ pub struct GraftApp {
     current_entry_id: Option<u64>,
 
     // Console output
-    console_output: Vec<String>,
+    console_output: Vec<ConsoleOutputLine>,
     console_scroll_to_bottom: bool,
 
     // Log
@@ -100,6 +126,9 @@ pub struct GraftApp {
     robocopy_child: Option<Child>,
     output_thread: Option<JoinHandle<()>>,
     hash_thread_source: Option<JoinHandle<Result<Vec<FileHash>, String>>>,
+
+    // Cancel flag for operations
+    cancel_requested: Arc<AtomicBool>,
 }
 
 impl GraftApp {
@@ -148,6 +177,7 @@ impl GraftApp {
             robocopy_child: None,
             output_thread: None,
             hash_thread_source: None,
+            cancel_requested: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -285,7 +315,8 @@ impl GraftApp {
     }
 
     fn add_console_line(&mut self, line: String) {
-        self.console_output.push(line);
+        let line_type = Self::detect_line_type(&line);
+        self.console_output.push(ConsoleOutputLine::new(line, line_type));
         self.console_scroll_to_bottom = true;
         // Keep console buffer reasonable
         if self.console_output.len() > 10000 {
@@ -293,8 +324,57 @@ impl GraftApp {
         }
     }
 
+    /// Detect the line type based on content
+    fn detect_line_type(line: &str) -> ConsoleLineType {
+        let trimmed = line.trim();
+        
+        // Command lines start with ">>>"
+        if trimmed.starts_with(">>>") {
+            return ConsoleLineType::Command;
+        }
+        
+        // Errors
+        if trimmed.contains("[ERROR]") || trimmed.contains("Error:") || trimmed.starts_with("❌") {
+            return ConsoleLineType::Error;
+        }
+        
+        // Warnings
+        if trimmed.contains("WARNING") || trimmed.starts_with("⚠") {
+            return ConsoleLineType::Warning;
+        }
+        
+        // Success indicators
+        if trimmed.contains("✓") || trimmed.contains("Success") || trimmed.contains("completed successfully") {
+            return ConsoleLineType::Success;
+        }
+        
+        // Summary lines (robocopy statistics)
+        if trimmed.starts_with("Dirs :") || trimmed.starts_with("Files :") || 
+           trimmed.starts_with("Bytes :") || trimmed.starts_with("Times :") || 
+           trimmed.starts_with("Speed :") || trimmed.contains("Total") && trimmed.contains("Copied") {
+            return ConsoleLineType::Summary;
+        }
+        
+        ConsoleLineType::Normal
+    }
+
     fn clear_console(&mut self) {
         self.console_output.clear();
+    }
+
+    fn cancel_operation(&mut self) {
+        self.cancel_requested.store(true, Ordering::Relaxed);
+        self.log("Cancel requested...");
+        self.add_console_line("⚠ Operation cancelled by user".to_string());
+        
+        // Kill robocopy process if running
+        if let Some(mut child) = self.robocopy_child.take() {
+            let _ = child.kill();
+            self.log("Terminated robocopy process");
+        }
+        
+        // Note: Hash threads will check cancel_requested and exit gracefully
+        self.state = AppState::Idle;
     }
 
     fn destructive_option_labels(&self) -> Vec<&'static str> {
@@ -315,6 +395,13 @@ impl GraftApp {
     }
 
     fn request_start_robocopy(&mut self) {
+        // Validate paths first
+        if let Err(error) = self.validate_paths() {
+            self.log(&format!("Validation Error: {}", error));
+            self.add_console_line(format!("❌ Error: {}", error));
+            return;
+        }
+
         let destructive = self.destructive_option_labels();
         if destructive.is_empty() {
             self.start_robocopy();
@@ -334,12 +421,68 @@ impl GraftApp {
         self.show_destructive_warning = true;
     }
 
-    fn start_robocopy(&mut self) {
-        if self.source_path.is_empty() || self.destination_path.is_empty() {
-            self.log("Error: Source and destination paths are required");
-            return;
+    /// Validate source and destination paths
+    fn validate_paths(&self) -> Result<(), String> {
+        use std::path::Path;
+
+        if self.source_path.is_empty() {
+            return Err("Source path cannot be empty".to_string());
         }
 
+        if self.destination_path.is_empty() {
+            return Err("Destination path cannot be empty".to_string());
+        }
+
+        // Normalize paths for comparison
+        let source = Path::new(&self.source_path);
+        let dest = Path::new(&self.destination_path);
+
+        // Check if source exists (unless it's a dry run)
+        if !self.options.dry_run.enabled && !source.exists() {
+            return Err(format!("Source path does not exist: {}", self.source_path));
+        }
+
+        // Check if paths are the same
+        if let (Ok(src_canon), Ok(dst_canon)) = (source.canonicalize(), dest.canonicalize()) {
+            if src_canon == dst_canon {
+                return Err("Source and destination cannot be the same path".to_string());
+            }
+        } else if self.source_path == self.destination_path {
+            // Fallback comparison if canonicalize fails
+            return Err("Source and destination cannot be the same path".to_string());
+        }
+
+        // Check if destination is inside source
+        if dest.starts_with(source) {
+            return Err("Destination cannot be inside the source directory".to_string());
+        }
+
+        // Check if source is inside destination (could cause issues with mirror/purge)
+        if source.starts_with(dest) && (self.options.mirror.enabled || self.options.purge.enabled) {
+            return Err("Source cannot be inside destination when using Mirror or Purge options".to_string());
+        }
+
+        // Check path length (Windows MAX_PATH is 260, but we'll be conservative)
+        if self.source_path.len() > 250 || self.destination_path.len() > 250 {
+            return Err("Path length exceeds safe limits (max 250 characters recommended)".to_string());
+        }
+
+        // Check for invalid characters in paths (Windows specific)
+        let invalid_chars = ['<', '>', '"', '|', '?', '*'];
+        for ch in invalid_chars {
+            if self.source_path.contains(ch) || self.destination_path.contains(ch) {
+                return Err(format!("Path contains invalid character: '{}'", ch));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn start_robocopy(&mut self) {
+        // Validation is done in request_start_robocopy, so we can proceed
+        // Reset cancel flag for new operation
+        self.cancel_requested.store(false, Ordering::Relaxed);
+        
         let command = self.options.build_command_string(&self.source_path, &self.destination_path);
         self.log_entries.clear(); // Clear log for new transfer
         self.log(&format!("Preset: {}", self.options.current_preset.name()));
@@ -436,7 +579,7 @@ impl GraftApp {
 
         // Search console output from the end for the summary lines
         for line in self.console_output.iter().rev().take(30) {
-            let trimmed = line.trim();
+            let trimmed = line.text.trim();
             if trimmed.starts_with("Dirs :") || trimmed.starts_with("Dirs:") {
                 let nums = Self::parse_stat_line(trimmed);
                 if nums.len() >= 6 {
@@ -630,7 +773,8 @@ impl GraftApp {
 
         // Start hashing source only
         let source_path = PathBuf::from(&self.source_path);
-        self.hash_thread_source = Some(hash_directory(&source_path, tx));
+        let cancel_flag = Arc::clone(&self.cancel_requested);
+        self.hash_thread_source = Some(hash_directory(&source_path, tx, cancel_flag));
 
         self.state = AppState::Hashing;
     }
@@ -712,17 +856,6 @@ impl GraftApp {
             
             self.state = AppState::Idle;
         }
-    }
-
-    fn stop_operation(&mut self) {
-        if let Some(mut child) = self.robocopy_child.take() {
-            let _ = child.kill();
-            self.log("Operation cancelled by user");
-            self.add_console_line(">>> Operation cancelled by user".to_string());
-        }
-        self.state = AppState::Idle;
-        self.console_rx = None;
-        self.output_thread = None;
     }
 
     fn export_log(&self) {
@@ -886,7 +1019,7 @@ impl eframe::App for GraftApp {
             ui.heading("GRAFT - Graphical Robocopy Assured File Transfer Tool");
             ui.add_space(8.0);
 
-            // Source path row
+            // Source path row with recent paths dropdown
             ui.horizontal(|ui| {
                 ui.label("Source:        ");
                 if ui.button("Browse...").clicked() {
@@ -894,6 +1027,21 @@ impl eframe::App for GraftApp {
                         self.source_path = path.to_string_lossy().to_string();
                     }
                 }
+                
+                // Recent paths dropdown
+                let recent_sources = self.history.get_recent_source_paths().to_vec();
+                if !recent_sources.is_empty() {
+                    egui::ComboBox::from_id_salt("recent_sources")
+                        .selected_text("Recent...")
+                        .show_ui(ui, |ui| {
+                            for recent_path in &recent_sources {
+                                if ui.selectable_label(false, recent_path).clicked() {
+                                    self.source_path = recent_path.clone();
+                                }
+                            }
+                        });
+                }
+                
                 ui.add(
                     egui::TextEdit::singleline(&mut self.source_path)
                         .desired_width(ui.available_width())
@@ -903,7 +1051,7 @@ impl eframe::App for GraftApp {
 
             ui.add_space(4.0);
 
-            // Destination path row
+            // Destination path row with recent paths dropdown
             ui.horizontal(|ui| {
                 ui.label("Destination:");
                 if ui.button("Browse...").clicked() {
@@ -911,6 +1059,21 @@ impl eframe::App for GraftApp {
                         self.destination_path = path.to_string_lossy().to_string();
                     }
                 }
+                
+                // Recent paths dropdown
+                let recent_dests = self.history.get_recent_dest_paths().to_vec();
+                if !recent_dests.is_empty() {
+                    egui::ComboBox::from_id_salt("recent_dests")
+                        .selected_text("Recent...")
+                        .show_ui(ui, |ui| {
+                            for recent_path in &recent_dests {
+                                if ui.selectable_label(false, recent_path).clicked() {
+                                    self.destination_path = recent_path.clone();
+                                }
+                            }
+                        });
+                }
+                
                 ui.add(
                     egui::TextEdit::singleline(&mut self.destination_path)
                         .desired_width(ui.available_width())
@@ -959,8 +1122,8 @@ impl eframe::App for GraftApp {
                         self.request_start_robocopy();
                     }
                 } else {
-                    if ui.button("⏹ Stop").clicked() {
-                        self.stop_operation();
+                    if ui.button("⏹ Cancel").clicked() {
+                        self.cancel_operation();
                     }
                 }
 
@@ -1049,7 +1212,15 @@ impl eframe::App for GraftApp {
                 scroll_area.show(ui, |ui| {
                     ui.style_mut().override_font_id = Some(egui::FontId::monospace(12.0));
                     for line in &self.console_output {
-                        ui.label(line);
+                        let color = match line.line_type {
+                            ConsoleLineType::Normal => ui.style().visuals.text_color(),
+                            ConsoleLineType::Command => egui::Color32::from_rgb(79, 195, 247),  // Cyan/blue
+                            ConsoleLineType::Success => egui::Color32::from_rgb(102, 187, 106), // Green
+                            ConsoleLineType::Warning => egui::Color32::from_rgb(255, 183, 77),  // Orange
+                            ConsoleLineType::Error => egui::Color32::from_rgb(255, 84, 73),     // Red
+                            ConsoleLineType::Summary => egui::Color32::from_rgb(149, 117, 205), // Purple
+                        };
+                        ui.colored_label(color, &line.text);
                     }
                 });
             });
@@ -1128,6 +1299,24 @@ impl GraftApp {
                 }
                 ui.add_space(8.0);
             }
+
+            // Dry Run mode - prominent option
+            ui.horizontal(|ui| {
+                ui.checkbox(&mut self.options.dry_run.enabled, &self.options.dry_run.name);
+                if self.options.dry_run.enabled {
+                    ui.label(
+                        egui::RichText::new("(Preview mode - no changes will be made)")
+                            .small()
+                            .color(egui::Color32::from_rgb(100, 180, 255)),
+                    );
+                }
+            });
+            ui.label(
+                egui::RichText::new(&self.options.dry_run.description)
+                    .small()
+                    .color(egui::Color32::GRAY),
+            );
+            ui.add_space(8.0);
 
             // Options in collapsible sections
             ui.columns(2, |columns| {

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -592,4 +592,59 @@ mod tests {
         
         cleanup_temp_dir(&temp_dir);
     }
+
+    #[test]
+    fn test_get_relative_path() {
+        use super::get_relative_path;
+        
+        let base = Path::new("/home/user/documents");
+        let file = Path::new("/home/user/documents/subfolder/file.txt");
+        
+        let relative = get_relative_path(base, file);
+        
+        // Path::strip_prefix returns paths with forward slashes on all platforms
+        assert_eq!(relative, "subfolder/file.txt");
+    }
+
+    #[test]
+    fn test_get_relative_path_same_path() {
+        use super::get_relative_path;
+        
+        let base = Path::new("/home/user/documents");
+        let file = Path::new("/home/user/documents");
+        
+        let relative = get_relative_path(base, file);
+        assert_eq!(relative, "");
+    }
+
+    #[test]
+    fn test_get_relative_path_not_prefix() {
+        use super::get_relative_path;
+        
+        let base = Path::new("/home/user/documents");
+        let file = Path::new("/other/path/file.txt");
+        
+        let relative = get_relative_path(base, file);
+        
+        // Should return the full path when not a prefix
+        #[cfg(windows)]
+        assert!(relative.contains("file.txt"));
+        
+        #[cfg(not(windows))]
+        assert_eq!(relative, "/other/path/file.txt");
+    }
+
+    #[test]
+    fn test_file_hash_structure() {
+        let hash = FileHash {
+            path: PathBuf::from("/test/file.txt"),
+            relative_path: "file.txt".to_string(),
+            hash: "abc123".to_string(),
+            size: 1024,
+        };
+        
+        assert_eq!(hash.relative_path, "file.txt");
+        assert_eq!(hash.hash, "abc123");
+        assert_eq!(hash.size, 1024);
+    }
 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -6,6 +6,8 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 use walkdir::WalkDir;
 
@@ -114,6 +116,7 @@ pub fn collect_files(dir: &Path) -> Result<Vec<PathBuf>, String> {
 pub fn hash_directory(
     dir: &Path,
     progress_tx: mpsc::Sender<HashProgress>,
+    cancel_flag: Arc<AtomicBool>,
 ) -> thread::JoinHandle<Result<Vec<FileHash>, String>> {
     let dir = dir.to_path_buf();
     
@@ -126,6 +129,12 @@ pub fn hash_directory(
         let mut hashes = Vec::new();
         
         for file_path in files {
+            // Check for cancellation
+            if cancel_flag.load(Ordering::Relaxed) {
+                let _ = progress_tx.send(HashProgress::Error("Cancelled by user".to_string()));
+                return Err("Cancelled by user".to_string());
+            }
+            
             let relative = get_relative_path(&dir, &file_path);
             let _ = progress_tx.send(HashProgress::FileStarted(relative.clone()));
             
@@ -563,7 +572,8 @@ mod tests {
         fs::write(temp_dir.join("file2.txt"), "content2").unwrap();
         
         let (tx, rx) = mpsc::channel();
-        let handle = hash_directory(&temp_dir, tx);
+        let cancel_flag = Arc::new(AtomicBool::new(false));
+        let handle = hash_directory(&temp_dir, tx, cancel_flag);
         
         // Collect progress updates
         let mut starting_count = 0;
@@ -646,5 +656,35 @@ mod tests {
         assert_eq!(hash.relative_path, "file.txt");
         assert_eq!(hash.hash, "abc123");
         assert_eq!(hash.size, 1024);
+    }
+
+    #[test]
+    fn test_hash_directory_cancellation() {
+        let temp_dir = create_temp_dir("hash_cancel");
+        
+        // Create several test files
+        for i in 0..10 {
+            fs::write(temp_dir.join(format!("file{}.txt", i)), format!("content{}", i)).unwrap();
+        }
+        
+        let (tx, rx) = mpsc::channel();
+        let cancel_flag = Arc::new(AtomicBool::new(false));
+        let cancel_clone = Arc::clone(&cancel_flag);
+        
+        let handle = hash_directory(&temp_dir, tx, cancel_clone);
+        
+        // Cancel after receiving first progress update
+        let _= rx.recv_timeout(std::time::Duration::from_secs(1));
+        cancel_flag.store(true, Ordering::Relaxed);
+        
+        // Wait for completion
+        let result = handle.join().expect("Hash thread panicked");
+        
+        // Should be cancelled        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(e.contains("Cancelled"));
+        }
+        
+        cleanup_temp_dir(&temp_dir);
     }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -488,4 +488,194 @@ mod tests {
         assert_eq!(restored.entries.len(), 1);
         assert_eq!(restored.entries[0].source, "C:\\Source");
     }
+
+    #[test]
+    fn test_history_entry_get_username() {
+        // This test checks that get_username returns something or None
+        let username = HistoryEntry::get_username();
+        
+        // On most systems, USERNAME or USER should be set
+        // We can't assert exact value, but can verify the function works
+        assert!(username.is_some() || username.is_none());
+    }
+
+    #[test]
+    fn test_history_entry_get_log_directory() {
+        let log_dir = HistoryEntry::get_log_directory();
+        
+        // Should return a path on most systems
+        if let Some(dir) = log_dir {
+            assert!(dir.to_string_lossy().contains("Graft"));
+            assert!(dir.to_string_lossy().contains("logs"));
+        }
+    }
+
+    #[test]
+    fn test_history_entry_generate_log_filename() {
+        let entry = create_test_entry("C:\\Source", "D:\\Dest");
+        let filename = entry.generate_log_filename();
+        
+        assert!(filename.starts_with("graft_"));
+        assert!(filename.ends_with(".log"));
+        assert!(filename.contains(&entry.timestamp.format("%Y-%m-%d").to_string()));
+    }
+
+    #[test]
+    fn test_history_entry_generate_log_filename_with_ticket() {
+        let mut entry = create_test_entry("C:\\Source", "D:\\Dest");
+        entry.ticket_number = Some("TICKET-123".to_string());
+        
+        let filename = entry.generate_log_filename();
+        
+        assert!(filename.contains("TICKET-123"));
+        assert!(filename.ends_with(".log"));
+    }
+
+    #[test]
+    fn test_history_entry_save_log_to_disk() {
+        let mut entry = create_test_entry("C:\\Source", "D:\\Dest");
+        entry.log_content = Some("Test log content\nLine 2\nLine 3".to_string());
+        
+        // Try to save (may fail if no permissions, which is okay for testing)
+        let result = entry.save_log_to_disk();
+        
+        if let Ok(log_path) = result {
+            // Verify the file was created
+            assert!(log_path.exists());
+            
+            // Read and verify content
+            let content = std::fs::read_to_string(&log_path).expect("Failed to read log file");
+            assert_eq!(content, "Test log content\nLine 2\nLine 3");
+            
+            // Cleanup
+            let _ = std::fs::remove_file(&log_path);
+        }
+    }
+
+    #[test]
+    fn test_history_entry_save_log_without_content() {
+        let entry = create_test_entry("C:\\Source", "D:\\Dest");
+        // No log_content set
+        
+        let result = entry.save_log_to_disk();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_command_history_set_log_content() {
+        let mut history = CommandHistory::new();
+        let entry = create_test_entry("C:\\Source", "D:\\Dest");
+        let entry_id = entry.id;
+        
+        history.add_entry(entry);
+        
+        history.set_log_content(entry_id, "Log content here".to_string(), Some("TKT-456".to_string()));
+        
+        assert_eq!(history.entries[0].log_content, Some("Log content here".to_string()));
+        assert_eq!(history.entries[0].ticket_number, Some("TKT-456".to_string()));
+    }
+
+    #[test]
+    fn test_command_history_set_log_content_without_ticket() {
+        let mut history = CommandHistory::new();
+        let entry = create_test_entry("C:\\Source", "D:\\Dest");
+        let entry_id = entry.id;
+        
+        history.add_entry(entry);
+        
+        history.set_log_content(entry_id, "Log without ticket".to_string(), None);
+        
+        assert_eq!(history.entries[0].log_content, Some("Log without ticket".to_string()));
+        assert_eq!(history.entries[0].ticket_number, None);
+    }
+
+    #[test]
+    fn test_command_history_get_entry_mut() {
+        let mut history = CommandHistory::new();
+        let entry = create_test_entry("C:\\Source", "D:\\Dest");
+        let entry_id = entry.id;
+        
+        history.add_entry(entry);
+        
+        // Get mutable reference and modify
+        if let Some(entry_mut) = history.get_entry_mut(entry_id) {
+            entry_mut.saved = true;
+        }
+        
+        assert!(history.entries[0].saved);
+    }
+
+    #[test]
+    fn test_command_history_get_entry_mut_not_found() {
+        let mut history = CommandHistory::new();
+        
+        let result = history.get_entry_mut(99999);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_command_history_save_last_config() {
+        let mut history = CommandHistory::new();
+        let options = RobocopyOptions::default();
+        
+        history.save_last_config(
+            "C:\\LastSource".to_string(),
+            "D:\\LastDest".to_string(),
+            options.clone(),
+        );
+        
+        assert!(history.last_config.is_some());
+        let config = history.last_config.as_ref().unwrap();
+        assert_eq!(config.source, "C:\\LastSource");
+        assert_eq!(config.destination, "D:\\LastDest");
+    }
+
+    #[test]
+    fn test_command_history_get_last_config() {
+        let mut history = CommandHistory::new();
+        
+        // No config saved yet
+        assert!(history.get_last_config().is_none());
+        
+        // Save a config
+        let options = RobocopyOptions::default();
+        history.save_last_config(
+            "C:\\Source".to_string(),
+            "D:\\Dest".to_string(),
+            options,
+        );
+        
+        // Now it should return the config
+        let config = history.get_last_config();
+        assert!(config.is_some());
+        assert_eq!(config.unwrap().source, "C:\\Source");
+    }
+
+    #[test]
+    fn test_command_history_display_name_with_ticket() {
+        let mut entry = create_test_entry("C:\\Source", "D:\\Dest");
+        entry.ticket_number = Some("TICKET-789".to_string());
+        
+        let display = entry.display_name();
+        
+        assert!(display.contains("[TICKET-789]"));
+    }
+
+    #[test]
+    fn test_last_config_serialization() {
+        let config = LastConfig {
+            source: "C:\\Test".to_string(),
+            destination: "D:\\Test".to_string(),
+            options: RobocopyOptions::default(),
+        };
+        
+        // Serialize to JSON
+        let json = serde_json::to_string(&config).expect("Failed to serialize");
+        
+        // Deserialize back
+        let restored: LastConfig = serde_json::from_str(&json).expect("Failed to deserialize");
+        
+        assert_eq!(restored.source, "C:\\Test");
+        assert_eq!(restored.destination, "D:\\Test");
+    }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -107,6 +107,12 @@ pub struct CommandHistory {
     pub entries: Vec<HistoryEntry>,
     pub max_entries: usize,
     pub last_config: Option<LastConfig>,
+    
+    #[serde(default)]
+    pub recent_source_paths: Vec<String>,
+    
+    #[serde(default)]
+    pub recent_dest_paths: Vec<String>,
 }
 
 /// Last used configuration
@@ -123,6 +129,8 @@ impl CommandHistory {
             entries: Vec::new(),
             max_entries: 100,
             last_config: None,
+            recent_source_paths: Vec::new(),
+            recent_dest_paths: Vec::new(),
         }
     }
 
@@ -165,6 +173,10 @@ impl CommandHistory {
 
     /// Add a new entry
     pub fn add_entry(&mut self, entry: HistoryEntry) {
+        // Update recent paths
+        self.add_recent_source_path(entry.source.clone());
+        self.add_recent_dest_path(entry.destination.clone());
+        
         self.entries.insert(0, entry);
         
         // Keep only max_entries (but always keep saved entries)
@@ -177,6 +189,52 @@ impl CommandHistory {
                 count <= self.max_entries
             }
         });
+    }
+
+    /// Add a path to recent sources (if not already at the top)
+    fn add_recent_source_path(&mut self, path: String) {
+        if path.is_empty() {
+            return;
+        }
+        
+        // Remove existing occurrence
+        self.recent_source_paths.retain(|p| p != &path);
+        
+        // Insert at front
+        self.recent_source_paths.insert(0, path);
+        
+        // Keep only last 10
+        if self.recent_source_paths.len() > 10 {
+            self.recent_source_paths.truncate(10);
+        }
+    }
+
+    /// Add a path to recent destinations (if not already at the top)
+    fn add_recent_dest_path(&mut self, path: String) {
+        if path.is_empty() {
+            return;
+        }
+        
+        // Remove existing occurrence
+        self.recent_dest_paths.retain(|p| p != &path);
+        
+        // Insert at front
+        self.recent_dest_paths.insert(0, path);
+        
+        // Keep only last 10
+        if self.recent_dest_paths.len() > 10 {
+            self.recent_dest_paths.truncate(10);
+        }
+    }
+
+    /// Get recent source paths
+    pub fn get_recent_source_paths(&self) -> &[String] {
+        &self.recent_source_paths
+    }
+
+    /// Get recent destination paths
+    pub fn get_recent_dest_paths(&self) -> &[String] {
+        &self.recent_dest_paths
     }
 
     /// Get recent entries (unsaved)
@@ -677,5 +735,64 @@ mod tests {
         
         assert_eq!(restored.source, "C:\\Test");
         assert_eq!(restored.destination, "D:\\Test");
+    }
+
+    #[test]
+    fn test_recent_paths_add() {
+        let mut history = CommandHistory::new();
+        
+        let entry1 = create_test_entry("C:\\Source1", "D:\\Dest1");
+        let entry2 = create_test_entry("C:\\Source2", "D:\\Dest2");
+        
+        history.add_entry(entry1);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        history.add_entry(entry2);
+        
+        let recent_sources = history.get_recent_source_paths();
+        let recent_dests = history.get_recent_dest_paths();
+        
+        assert_eq!(recent_sources.len(), 2);
+        assert_eq!(recent_dests.len(), 2);
+        
+        // Most recent should be first
+        assert_eq!(recent_sources[0], "C:\\Source2");
+        assert_eq!(recent_dests[0], "D:\\Dest2");
+    }
+
+    #[test]
+    fn test_recent_paths_dedup() {
+        let mut history = CommandHistory::new();
+        
+        let entry1 = create_test_entry("C:\\Source", "D:\\Dest1");
+        let entry2 = create_test_entry("C:\\Source", "D:\\Dest2");
+        
+        history.add_entry(entry1);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        history.add_entry(entry2);
+        
+        let recent_sources = history.get_recent_source_paths();
+        
+        // Should only have one copy of C:\\Source
+        assert_eq!(recent_sources.len(), 1);
+        assert_eq!(recent_sources[0], "C:\\Source");
+    }
+
+    #[test]
+    fn test_recent_paths_limit() {
+        let mut history = CommandHistory::new();
+        
+        // Add 15 entries
+        for i in 0..15 {
+            let entry = create_test_entry(&format!("C:\\Source{}", i), &format!("D:\\Dest{}", i));
+            history.add_entry(entry);
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        
+        // Should only keep last 10
+        assert_eq!(history.get_recent_source_paths().len(), 10);
+        assert_eq!(history.get_recent_dest_paths().len(), 10);
+        
+        // Most recent should be first
+        assert_eq!(history.get_recent_source_paths()[0], "C:\\Source14");
     }
 }

--- a/src/robocopy.rs
+++ b/src/robocopy.rs
@@ -124,6 +124,9 @@ pub struct RobocopyOptions {
     pub multi_thread: RobocopyOption,
     pub inter_packet_gap: RobocopyOption,
 
+    // Special modes
+    pub dry_run: RobocopyOption,
+
     // Current preset
     pub current_preset: PresetGroup,
 }
@@ -181,6 +184,9 @@ impl Default for RobocopyOptions {
             // Performance
             multi_thread: RobocopyOption::with_value("/MT:", "Multi-threaded", "Multi-threaded copy with N threads (default 8, max 128)", "8"),
             inter_packet_gap: RobocopyOption::with_value("/IPG:", "Inter-Packet Gap", "Inter-packet gap in milliseconds (for bandwidth throttling)", ""),
+
+            // Special modes
+            dry_run: RobocopyOption::new("/L", "Dry Run (List Only)", "List only - don't copy, delete or timestamp any files"),
 
             current_preset: DEFAULT_PRESET,
         };
@@ -248,6 +254,9 @@ impl RobocopyOptions {
             // Performance
             multi_thread: RobocopyOption::with_value("/MT:", "Multi-threaded", "Multi-threaded copy with N threads (default 8, max 128)", "8"),
             inter_packet_gap: RobocopyOption::with_value("/IPG:", "Inter-Packet Gap", "Inter-packet gap in milliseconds (for bandwidth throttling)", ""),
+
+            // Special modes
+            dry_run: RobocopyOption::new("/L", "Dry Run (List Only)", "List only - don't copy, delete or timestamp any files"),
 
             current_preset: PresetGroup::None,
         }
@@ -393,7 +402,9 @@ impl RobocopyOptions {
         self.multi_thread.enabled == other.multi_thread.enabled &&
         self.multi_thread.value == other.multi_thread.value &&
         self.inter_packet_gap.enabled == other.inter_packet_gap.enabled &&
-        self.inter_packet_gap.value == other.inter_packet_gap.value
+        self.inter_packet_gap.value == other.inter_packet_gap.value &&
+        
+        self.dry_run.enabled == other.dry_run.enabled
     }
 
     /// Reset all options to disabled
@@ -457,6 +468,9 @@ impl RobocopyOptions {
         self.multi_thread.value = default.multi_thread.value;
         self.inter_packet_gap.enabled = false;
         self.inter_packet_gap.value = default.inter_packet_gap.value;
+
+        // Special modes
+        self.dry_run.enabled = false;
     }
 
     /// Build the command line arguments
@@ -525,6 +539,9 @@ impl RobocopyOptions {
         // Performance
         add_opt(&mut args, &self.multi_thread);
         add_opt(&mut args, &self.inter_packet_gap);
+
+        // Special modes
+        add_opt(&mut args, &self.dry_run);
 
         args
     }
@@ -953,5 +970,18 @@ mod tests {
         
         assert!(args.contains(&"/A+:RH".to_string()));
         assert!(args.contains(&"/A-:A".to_string()));
+    }
+
+    #[test]
+    fn test_dry_run_mode() {
+        let mut options = RobocopyOptions::new_empty();
+        options.dry_run.enabled = true;
+        
+        let args = options.build_args("C:\\src", "D:\\dst");
+        
+        assert!(args.contains(&"/L".to_string()));
+        
+        let cmd = options.build_command_string("C:\\src", "D:\\dst");
+        assert!(cmd.contains("/L"));
     }
 }

--- a/src/robocopy.rs
+++ b/src/robocopy.rs
@@ -728,4 +728,230 @@ mod tests {
         assert!(opt.has_value);
         assert_eq!(opt.value, "default");
     }
+
+    #[test]
+    fn test_preset_descriptions() {
+        // Verify all presets have descriptions
+        assert!(!PresetGroup::None.description().is_empty());
+        assert!(!PresetGroup::LargeFilesWan.description().is_empty());
+        assert!(!PresetGroup::MirrorWithMetadata.description().is_empty());
+        assert!(!PresetGroup::CopyAllPreserve.description().is_empty());
+        assert!(!PresetGroup::IncrementalBackup.description().is_empty());
+        assert!(!PresetGroup::QuickCopy.description().is_empty());
+        
+        // Verify descriptions are meaningful
+        assert!(PresetGroup::LargeFilesWan.description().contains("WAN"));
+        assert!(PresetGroup::MirrorWithMetadata.description().contains("mirror"));
+        assert!(PresetGroup::IncrementalBackup.description().contains("new or changed"));
+    }
+
+    #[test]
+    fn test_matches_current_preset_true() {
+        let mut options = RobocopyOptions::default();
+        
+        // Default preset is LargeFilesWan, so it should match
+        assert!(options.matches_current_preset());
+        
+        // Apply a different preset and verify it matches
+        options.apply_preset(PresetGroup::QuickCopy);
+        assert!(options.matches_current_preset());
+    }
+
+    #[test]
+    fn test_matches_current_preset_false_after_modification() {
+        let mut options = RobocopyOptions::default();
+        options.apply_preset(PresetGroup::QuickCopy);
+        
+        // Verify it matches initially
+        assert!(options.matches_current_preset());
+        
+        // Modify an option
+        options.copy_backup.enabled = true;
+        
+        // Now it should not match
+        assert!(!options.matches_current_preset());
+    }
+
+    #[test]
+    fn test_matches_current_preset_custom_always_matches() {
+        let mut options = RobocopyOptions::new_empty();
+        options.current_preset = PresetGroup::None;
+        
+        // Custom preset always matches
+        assert!(options.matches_current_preset());
+        
+        // Even after modifications
+        options.mirror.enabled = true;
+        assert!(options.matches_current_preset());
+    }
+
+    #[test]
+    fn test_options_equal() {
+        let options1 = RobocopyOptions::default();
+        let options2 = RobocopyOptions::default();
+        
+        assert!(options1.options_equal(&options2));
+    }
+
+    #[test]
+    fn test_options_not_equal_different_enabled() {
+        let mut options1 = RobocopyOptions::default();
+        let options2 = RobocopyOptions::default();
+        
+        options1.copy_backup.enabled = true;
+        
+        assert!(!options1.options_equal(&options2));
+    }
+
+    #[test]
+    fn test_options_not_equal_different_values() {
+        let mut options1 = RobocopyOptions::default();
+        let mut options2 = RobocopyOptions::default();
+        
+        options1.multi_thread.enabled = true;
+        options1.multi_thread.value = "16".to_string();
+        
+        options2.multi_thread.enabled = true;
+        options2.multi_thread.value = "8".to_string();
+        
+        assert!(!options1.options_equal(&options2));
+    }
+
+    #[test]
+    fn test_build_command_string() {
+        let mut options = RobocopyOptions::new_empty();
+        options.copy_subdirs_empty.enabled = true;
+        options.mirror.enabled = true;
+        
+        let cmd = options.build_command_string("C:\\source", "D:\\destination");
+        
+        assert!(cmd.starts_with("robocopy"));
+        assert!(cmd.contains("C:\\source"));
+        assert!(cmd.contains("D:\\destination"));
+        assert!(cmd.contains("/E"));
+        assert!(cmd.contains("/MIR"));
+    }
+
+    #[test]
+    fn test_build_command_string_with_quoted_paths() {
+        let options = RobocopyOptions::new_empty();
+        
+        let cmd = options.build_command_string("C:\\path with spaces", "D:\\another path");
+        
+        assert!(cmd.contains("C:\\path with spaces"));
+        assert!(cmd.contains("D:\\another path"));
+    }
+
+    #[test]
+    fn test_build_command_string_with_values() {
+        let mut options = RobocopyOptions::new_empty();
+        options.retry_count.enabled = true;
+        options.retry_count.value = "5".to_string();
+        options.multi_thread.enabled = true;
+        options.multi_thread.value = "16".to_string();
+        
+        let cmd = options.build_command_string("C:\\src", "D:\\dst");
+        
+        assert!(cmd.contains("/R:5"));
+        assert!(cmd.contains("/MT:16"));
+    }
+
+    #[test]
+    fn test_new_empty_creates_disabled_options() {
+        let options = RobocopyOptions::new_empty();
+        
+        assert!(!options.copy_subdirs.enabled);
+        assert!(!options.copy_subdirs_empty.enabled);
+        assert!(!options.mirror.enabled);
+        assert!(!options.copy_all.enabled);
+        assert!(!options.multi_thread.enabled);
+        assert_eq!(options.current_preset, PresetGroup::None);
+    }
+
+    #[test]
+    fn test_default_applies_preset() {
+        let options = RobocopyOptions::default();
+        
+        // Default should apply LargeFilesWan preset
+        assert_eq!(options.current_preset, PresetGroup::LargeFilesWan);
+        assert!(options.copy_subdirs_empty.enabled);
+        assert!(options.copy_unbuffered.enabled);
+    }
+
+    #[test]
+    fn test_preset_application_resets_previous_options() {
+        let mut options = RobocopyOptions::default();
+        
+        // Apply one preset
+        options.apply_preset(PresetGroup::MirrorWithMetadata);
+        assert!(options.mirror.enabled);
+        
+        // Apply another preset - should reset previous options
+        options.apply_preset(PresetGroup::QuickCopy);
+        assert!(!options.mirror.enabled);
+        assert!(options.copy_subdirs_empty.enabled);
+    }
+
+    #[test]
+    fn test_all_presets_produce_valid_commands() {
+        let presets = vec![
+            PresetGroup::None,
+            PresetGroup::LargeFilesWan,
+            PresetGroup::MirrorWithMetadata,
+            PresetGroup::CopyAllPreserve,
+            PresetGroup::IncrementalBackup,
+            PresetGroup::QuickCopy,
+        ];
+        
+        for preset in presets {
+            let mut options = RobocopyOptions::default();
+            options.apply_preset(preset.clone());
+            
+            let cmd = options.build_command_string("C:\\src", "D:\\dst");
+            
+            // Should always start with robocopy
+            assert!(cmd.starts_with("robocopy"));
+            
+            // Should contain source and destination
+            assert!(cmd.contains("C:\\src"));
+            assert!(cmd.contains("D:\\dst"));
+        }
+    }
+
+    #[test]
+    fn test_option_flag_format() {
+        let opt1 = RobocopyOption::new("/TEST", "Test", "Description");
+        assert!(opt1.flag.starts_with('/'));
+        
+        let opt2 = RobocopyOption::with_value("/VAL:", "Value", "Description", "default");
+        assert!(opt2.flag.ends_with(':'));
+    }
+
+    #[test]
+    fn test_build_args_order_is_consistent() {
+        let mut options = RobocopyOptions::new_empty();
+        options.copy_subdirs_empty.enabled = true;
+        options.retry_count.enabled = true;
+        options.retry_count.value = "3".to_string();
+        
+        let args1 = options.build_args("C:\\src", "D:\\dst");
+        let args2 = options.build_args("C:\\src", "D:\\dst");
+        
+        // Should produce identical args
+        assert_eq!(args1, args2);
+    }
+
+    #[test]
+    fn test_attribute_options() {
+        let mut options = RobocopyOptions::new_empty();
+        options.attr_add.enabled = true;
+        options.attr_add.value = "RH".to_string();
+        options.attr_remove.enabled = true;
+        options.attr_remove.value = "A".to_string();
+        
+        let args = options.build_args("C:\\src", "D:\\dst");
+        
+        assert!(args.contains(&"/A+:RH".to_string()));
+        assert!(args.contains(&"/A-:A".to_string()));
+    }
 }


### PR DESCRIPTION
This pull request introduces several significant improvements to the GRAFT application, focusing on enhanced user experience, improved safety, and better console output handling. The most notable changes include adding syntax highlighting for console output, robust path validation to prevent user errors, support for operation cancellation (including hash operations), and improved usability with recent path dropdowns and a more prominent Dry Run mode.

**Key improvements:**

### Console Output Enhancements
* Added a `ConsoleOutputLine` struct and `ConsoleLineType` enum to classify and store console output lines with metadata, enabling syntax highlighting for different types of messages (commands, errors, warnings, successes, summaries, etc.) in the UI. [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R34-R57) [[2]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L69-R95) [[3]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L288-R379) [[4]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L1052-R1223)
* Updated the UI to render console output with color coding based on line type, improving readability and user experience.

### Path Validation and User Safety
* Implemented comprehensive path validation before starting operations, including checks for empty paths, existence, path equality, nesting, length, and invalid characters, to prevent common user mistakes and potential data loss. [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R398-R404) [[2]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L337-R485)

### Operation Cancellation
* Introduced a thread-safe cancel flag (`cancel_requested`) to allow users to cancel running operations, including both robocopy and hashing threads. The UI now provides a "Cancel" button, and cancellation is handled gracefully in both the main app and hashing logic. [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R129-R131) [[2]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R180) [[3]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L288-R379) [[4]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L962-R1126) [[5]](diffhunk://#diff-36fa6755375e7cfc32016edb8219a432b780c478f64569bb880107ca451fb0caR9-R10) [[6]](diffhunk://#diff-36fa6755375e7cfc32016edb8219a432b780c478f64569bb880107ca451fb0caR119) [[7]](diffhunk://#diff-36fa6755375e7cfc32016edb8219a432b780c478f64569bb880107ca451fb0caR132-R137) [[8]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L633-R777) [[9]](diffhunk://#diff-36fa6755375e7cfc32016edb8219a432b780c478f64569bb880107ca451fb0caL566-R576)

### Usability Improvements
* Added dropdowns for quickly selecting recent source and destination paths, streamlining the process of setting up transfers. [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L889-R1044) [[2]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L906-R1076)
* Made the Dry Run mode more prominent in the UI, with a clear description and highlighted status to encourage safer testing of operations.

### Miscellaneous
* Bumped the application version from 1.0.2 to 1.0.3 in `Cargo.toml`.